### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -105,7 +105,7 @@ please do <TASK NUMBER>
 # Mark task as undone
 please undo <TASK NUMBER>
 
-# Show tasks even if all tasks are markded as done
+# Show tasks even if all tasks are marked as done
 please showtasks
 
 # Move task to specified position


### PR DESCRIPTION
Noticed an extra letter in the word "marked" in the README. Now it's fixed.