### PR TITLE
add task edit function

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -111,6 +111,9 @@ please delete <TASK NUMBER>
 # Mark task as done
 please do <TASK NUMBER>
 
+# Edit task name
+please edit <TASK NUMBER> <NEW NAME>
+
 # Mark task as undone
 please undo <TASK NUMBER>
 

--- a/please/please.py
+++ b/please/please.py
@@ -175,11 +175,20 @@ def move(old_index: int, new_index: int):
 
 @app.command(short_help="Edit task name")
 def edit(index: int, new_name: str) -> None:
+    if not 0 <= index - 1 < len(config["tasks"]):
+        center_print(
+            "Are you sure you gave me the correct task number?",
+            COLOR_WARNING,
+            wrap=True,
+        )
+        return
+
     if (len(config["tasks"]) == 0):
         center_print(
             "Sorry, cannot edit tasks as the Task list is empty", COLOR_ERROR
         )
         return
+
     if (len(new_name) == 0):
         center_print(
             "Please enter a valid name", COLOR_ERROR

--- a/please/please.py
+++ b/please/please.py
@@ -173,6 +173,27 @@ def move(old_index: int, new_index: int):
             "Please check the entered index values", COLOR_WARNING
         )
 
+@app.command(short_help="Edit task name")
+def edit(index: int, new_name: str) -> None:
+    if (len(config["tasks"]) == 0):
+        center_print(
+            "Sorry, cannot edit tasks as the Task list is empty", COLOR_ERROR
+        )
+        return
+
+    try:
+        old_name = config["tasks"][index - 1]["name"]
+        config["tasks"][index - 1]["name"] = new_name
+        write_config(config)
+        if old_name != new_name:
+            center_print("Updated Task Name", COLOR_SUCCESS)
+        else:
+            center_print("No Updates Made", COLOR_INFO)
+        print_tasks(config["tasks"])
+    except:
+        center(
+            "Please check the entered Task index and new Task name", COLOR_WARNING
+        )
 
 @app.command(short_help="Clean up tasks marked as done from the task list")
 def clean() -> None:

--- a/please/please.py
+++ b/please/please.py
@@ -180,6 +180,11 @@ def edit(index: int, new_name: str) -> None:
             "Sorry, cannot edit tasks as the Task list is empty", COLOR_ERROR
         )
         return
+    if (len(new_name) == 0):
+        center_print(
+            "Please enter a valid name", COLOR_ERROR
+        )
+        return
 
     try:
         old_name = config["tasks"][index - 1]["name"]


### PR DESCRIPTION
Right now, if you mispelled task name or just want to change it, your only option is to delete the task and create a new one, losing the order and status of it. This PR adds `edit` function allowing you to change the name of a task without all that hassle.

Hope, you find it useful!
