### PR TITLE
Added new config Options

### DIFF
--- a/please/please.py
+++ b/please/please.py
@@ -332,8 +332,8 @@ def setup() -> None:
     config["disable_greeting"] = False
     config["time_format_24h"] = False
     config["last_reminder"] = None
-    conig["done_icon"] = "✅"
-    conig["notdone_icon"] = "❌"
+    config["done_icon"] = "✅"
+    config["notdone_icon"] = "❌"
     write_config(config)
 
 

--- a/please/please.py
+++ b/please/please.py
@@ -273,11 +273,11 @@ def showtasks() -> None:
         for index, task in enumerate(task_num):
             if task["done"]:
                 task_name = f"[#A0FF55] {task['name']}[/]"
-                task_status = "✅"
+                task_status = f'{config.get("done_icon", "✅")}'
                 task_index = f"[#A0FF55] {str(index + 1)} [/]"
             else:
                 task_name = f"[#FF5555] {task['name']}[/]"
-                task_status = "❌"
+                task_status = f'{config.get("notdone_icon", "❌")}'
                 task_index = f"[#FF5555] {str(index + 1)} [/]"
 
             table1.add_row(task_index, task_name, task_status)
@@ -332,6 +332,8 @@ def setup() -> None:
     config["disable_greeting"] = False
     config["time_format_24h"] = False
     config["last_reminder"] = None
+    conig["done_icon"] = "✅"
+    conig["notdone_icon"] = "❌"
     write_config(config)
 
 


### PR DESCRIPTION
This allows the user to put any glyphs in their config to represent their to-do status. Sources to get glyphs [nerd font](https://www.nerdfonts.com/)

The new config may look like this:
```json
{
  "user_name": "Nikhil Singh",
  "initial_setup_done": true,
  "tasks": [],
  "disable_line": false,
  "disable_quotes": false,
  "disable_greeting": false,
  "done_icon": "",
  "notdone_icon": "",
  "time_format_24h": false
}
```
This will not break the user's previous config as the options `done_icon` and `notdone_icon` are optional.